### PR TITLE
Remove life cycle method on Editor, move to data function

### DIFF
--- a/src/components/editor/Editor.vue
+++ b/src/components/editor/Editor.vue
@@ -30,12 +30,8 @@ export default {
   },
   data: function () {
     return {
-      graph: null
+      graph: new joint.dia.Graph()
     }
-  },
-  mounted () {
-    let graph = new joint.dia.Graph()
-    this.graph = graph
   }
 }
 </script>


### PR DESCRIPTION
Editor originally initialized graph as null, and then set it to a new joint.dia.Graph() in a mounted life cycle method.  

The paper class' mounted() lifecycle method uses this graph variable, but was getting invoked before graph was actually being set.  

As a result, I removed the lifecycle method and initialize the graph variable in the data function.