### PR TITLE
Emit event from Paper when the current element selection changes

### DIFF
--- a/src/components/editor/Paper.vue
+++ b/src/components/editor/Paper.vue
@@ -18,46 +18,44 @@ export default {
     // Define paper
     const paper = new joint.dia.Paper({
       el: this.$refs.paper,
-      width: 500,
-      height: 500,
       gridSize: 1,
       model: graph
     })
 
-    // When clicking a JointJS element, set it as the current element in Vue
+    // When clicking a JointJS element, emit event containing element model
     paper.on('cell:pointerdown',
       (cellView) => {
-        vue.currEl = cellView.model.attributes.attrs.text.text
+        vue.$emit('send-element', cellView.model)
       },
     )
 
     // Define some basic shapes
-    const r1 = new joint.shapes.basic.Rect({
+    const usersTable = new joint.shapes.basic.Rect({
       position: { x: 20, y: 20 },
       size: { width: 200, height: 200 },
       attrs: {
         rect: { fill: '#E74C3C' },
-        text: { text: 'Demo Table (Parent)', 'ref-y': 15 }
+        text: { text: 'users', 'ref-y': 15 }
       }
     })
-    const r2 = new joint.shapes.basic.Rect({
+    const colId = new joint.shapes.basic.Rect({
       position: { x: 20, y: 60 },
-      size: { width: 190, height: 40 },
-      attrs: { rect: { fill: '#F1C40F' }, text: { text: 'Col 1 (Child)' } }
+      size: { width: 200, height: 40 },
+      attrs: { rect: { fill: '#F1C40F' }, text: { text: 'id' } }
     })
 
-    const r3 = new joint.shapes.basic.Rect({
+    const colUsername = new joint.shapes.basic.Rect({
       position: { x: 20, y: 100 },
-      size: { width: 190, height: 40 },
-      attrs: { rect: { fill: '#F1C40F' }, text: { text: 'Col 2 (Child)' } }
+      size: { width: 200, height: 40 },
+      attrs: { rect: { fill: '#F1C40F' }, text: { text: 'username' } }
     })
 
     // Make column elements be inside the table element
-    r1.embed(r2)
-    r1.embed(r3)
+    usersTable.embed(colId)
+    usersTable.embed(colUsername)
 
     // Add the cells to the graph (model)
-    graph.addCells([r1, r2, r3])
+    graph.addCells([usersTable, colId, colUsername])
 
     // Handle bounding child elements inside parent element
     graph.on('change:position', (cell) => {


### PR DESCRIPTION
When the user clicks on a JointJS paper element (column, table, etc), the Paper Vue component will emit an event and pass up the model of the currently selected element. This will allow the side panels to modify the JointJS models and update the diagram.