### PR TITLE
Refactor JointJS graph and paper setup into util file

### DIFF
--- a/src/components/editor/Editor.vue
+++ b/src/components/editor/Editor.vue
@@ -25,17 +25,15 @@
 </template>
 
 <script>
-import joint from 'jointjs'
+import { createGraph } from '../../util/jointjs_util'
 import Paper from './Paper'
 export default {
   components: {
     Paper
   },
   data: function () {
-    let graph = new joint.dia.Graph()
-    window.graph = graph
     return {
-      graph: graph,
+      graph: createGraph(),
       currentElement: null
     }
   },

--- a/src/components/editor/Paper.vue
+++ b/src/components/editor/Paper.vue
@@ -5,8 +5,7 @@
 </template>
 
 <script>
-import joint from 'jointjs'
-import { createPaper } from '../../util/jointjs_util'
+import { createPaper, createTable } from '../../util/jointjs_util'
 
 export default {
   props: ['graph'],
@@ -21,30 +20,10 @@ export default {
     // Set up paper
     this.paper = createPaper(this.$refs.paper, graph, this)
 
-    // Define some basic shapes
-    const usersTable = new joint.shapes.basic.Rect({
-      position: { x: 20, y: 20 },
-      size: { width: 200, height: 200 },
-      attrs: {
-        rect: { fill: '#E74C3C' },
-        text: { text: 'users', 'ref-y': 15 }
-      }
-    })
-    const colId = new joint.shapes.basic.Rect({
-      position: { x: 20, y: 60 },
-      size: { width: 200, height: 40 },
-      attrs: { rect: { fill: '#F1C40F' }, text: { text: 'id' } }
-    })
-
-    const colUsername = new joint.shapes.basic.Rect({
-      position: { x: 20, y: 100 },
-      size: { width: 200, height: 40 },
-      attrs: { rect: { fill: '#F1C40F' }, text: { text: 'username' } }
-    })
-
-    // Make column elements be inside the table element
-    usersTable.embed(colId)
-    usersTable.embed(colUsername)
+    // Define sample table with two columns
+    const usersTable = createTable('users')
+    const colId = usersTable.attributes.addColumn('id')
+    const colUsername = usersTable.attributes.addColumn('username')
 
     // Add the cells to the graph (model)
     graph.addCells([usersTable, colId, colUsername])

--- a/src/components/editor/Paper.vue
+++ b/src/components/editor/Paper.vue
@@ -6,28 +6,20 @@
 
 <script>
 import joint from 'jointjs'
+import { createPaper } from '../../util/jointjs_util'
 
 export default {
   props: ['graph'],
+  data () {
+    return {
+      paper: null
+    }
+  },
   mounted () {
-    // Store reference to the Vue element
-    const vue = this
     // Pull graph out of props
     const graph = this.graph
-
-    // Define paper
-    const paper = new joint.dia.Paper({
-      el: this.$refs.paper,
-      gridSize: 1,
-      model: graph
-    })
-
-    // When clicking a JointJS element, emit event containing element model
-    paper.on('cell:pointerdown',
-      (cellView) => {
-        vue.$emit('send-element', cellView.model)
-      },
-    )
+    // Set up paper
+    this.paper = createPaper(this.$refs.paper, graph, this)
 
     // Define some basic shapes
     const usersTable = new joint.shapes.basic.Rect({
@@ -56,33 +48,6 @@ export default {
 
     // Add the cells to the graph (model)
     graph.addCells([usersTable, colId, colUsername])
-
-    // Handle bounding child elements inside parent element
-    graph.on('change:position', (cell, newPosition) => {
-      const parentId = cell.get('parent')
-
-      // Move the element if it doesn't have a parent
-      if (!parentId) return
-
-      if (!cell.get('originalPosition')) {
-        // Set originalPosition the first time
-        cell.set('position', cell.previous('position'))
-        cell.set('originalPosition', cell.position({ parentRelative: true }))
-        cell.set('position', newPosition)
-      }
-
-      // Calculate relative offsets
-      let relativePos = cell.position({ parentRelative: true })
-      let offsetY = cell.position({ parentRelative: true }).y - cell.get('originalPosition').y
-
-      // Reset child position if its relative position has changed
-      if (offsetY || relativePos.x) {
-        cell.set('position', cell.previous('position'))
-      }
-
-      // Update originalPosition
-      cell.set('originalPosition', cell.position({ parentRelative: true }))
-    })
   }
 }
 </script>

--- a/src/util/jointjs_util.js
+++ b/src/util/jointjs_util.js
@@ -27,8 +27,8 @@ export const createGraph = () => {
     // Move the element if it doesn't have a parent
     if (!parentId) return
 
+    // Set originalPosition to the relative position of the column
     if (!cell.get('originalPosition')) {
-      // Set originalPosition the first time
       cell.set('position', cell.previous('position'))
       cell.set('originalPosition', cell.position({ parentRelative: true }))
       cell.set('position', newPosition)
@@ -48,4 +48,51 @@ export const createGraph = () => {
   })
 
   return graph
+}
+
+export const createTable = (name) => {
+  // Display constants
+  const ROW_HEIGHT = 40
+  const WIDTH = 200
+  const TITLE_COLOR = '#CCCCCC'
+  const BG_COLOR_1 = '#F8F8F8'
+  const BG_COLOR_2 = '#EEEEEE'
+  const TITLE_Y_OFFSET = 20
+  const TITLE_X_OFFSET = 25
+
+  // Create table
+  const table = new joint.shapes.basic.Rect({
+    position: { x: 20, y: 20 },
+    size: { width: WIDTH, height: ROW_HEIGHT + 20 },
+    attrs: {
+      rect: { fill: TITLE_COLOR },
+      text: { text: name, 'ref-y': TITLE_Y_OFFSET, 'ref-x': TITLE_X_OFFSET }
+    },
+    columns: [],
+    addColumn (name) {
+      // Pull the relevant properties out of the table
+      const { columns, position, size } = this.attributes
+      const color = columns.length % 2 === 0 ? BG_COLOR_1 : BG_COLOR_2
+      const yPos = position.y + (columns.length * 40) + 40
+
+      // Create the column
+      const column = new joint.shapes.basic.Rect({
+        position: { x: position.x, y: yPos },
+        size: { width: WIDTH, height: ROW_HEIGHT },
+        attrs: { rect: { fill: color }, text: { text: name } }
+      })
+
+      // Resize the table to fit new column, embed and track the new column
+      this.resize(size.width, size.height + 40)
+      this.embed(column)
+      columns.push(column)
+
+      return column
+    }
+  })
+
+  // Bind the addColumn method to the table object
+  table.attributes.addColumn = table.attributes.addColumn.bind(table)
+
+  return table
 }

--- a/src/util/jointjs_util.js
+++ b/src/util/jointjs_util.js
@@ -1,0 +1,51 @@
+import joint from 'jointjs'
+
+export const createPaper = (element, graph, component) => {
+  // Define paper
+  const paper = new joint.dia.Paper({
+    el: element,
+    gridSize: 1,
+    model: graph
+  })
+
+  // When clicking a JointJS element, emit event containing element model
+  paper.on('cell:pointerdown',
+    (cellView) => {
+      component.$emit('send-element', cellView.model)
+    },
+  )
+}
+
+export const createGraph = () => {
+  // Initialize graph
+  const graph = new joint.dia.Graph()
+
+  // Handle bounding child elements inside parent element
+  graph.on('change:position', (cell, newPosition) => {
+    const parentId = cell.get('parent')
+
+    // Move the element if it doesn't have a parent
+    if (!parentId) return
+
+    if (!cell.get('originalPosition')) {
+      // Set originalPosition the first time
+      cell.set('position', cell.previous('position'))
+      cell.set('originalPosition', cell.position({ parentRelative: true }))
+      cell.set('position', newPosition)
+    }
+
+    // Calculate relative offsets
+    let relativePos = cell.position({ parentRelative: true })
+    let offsetY = cell.position({ parentRelative: true }).y - cell.get('originalPosition').y
+
+    // Reset child position if its relative position has changed
+    if (offsetY || relativePos.x) {
+      cell.set('position', cell.previous('position'))
+    }
+
+    // Update originalPosition
+    cell.set('originalPosition', cell.position({ parentRelative: true }))
+  })
+
+  return graph
+}


### PR DESCRIPTION
- Created src/util/jointjs_util.js
- Refactored JointJS logic out of Editor and Paper components

This util module will house all JointJS logic. I have refactored the graph and paper creation into functions called createGraph and createPaper, which create the associated objects and set up the needed event bindings. The util file will also be used to create factory methods for defining tables and columns.