### PR TITLE
Remove ambiguity and redundancy in editor routes

### DIFF
--- a/src/components/Navbar.vue
+++ b/src/components/Navbar.vue
@@ -22,7 +22,7 @@ export default {
     handleNewDb: function (e) {
       // this.$router.push({path: 'editor/new', query: { user_id: 'private' }})
       e.preventDefault()
-      this.$router.push('/editor/new')
+      this.$router.push('/editor')
     },
     goToFeatures: function (e) {
       // this.$router.push({path: 'editor/new', query: { user_id: 'private' }})

--- a/src/components/editor/Editor.vue
+++ b/src/components/editor/Editor.vue
@@ -89,7 +89,9 @@ export default {
     }
   },
   created () {
-    fetchGraph(1).then(res => console.log(res))
+    if (this.$route.params.id) {
+      fetchGraph(this.$route.params.id).then(res => console.log(res))
+    }
 
     this.graph = new Graph(this.$store)
     this.$store.commit(RECEIVE_ERRORS, { errors: ['select an element'] })

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -28,12 +28,12 @@ const router = new Router({
     },
     {
       path: '/editor',
-      name: 'editor_blank',
+      name: 'newDb',
       component: Editor
     },
     {
       path: '/editor/:id',
-      name: 'editor',
+      name: 'loadDb',
       component: Editor
     },
     {


### PR DESCRIPTION
Remove editor/new route.

New db page is just "/editor/"

Existing db pages found under "/editor/:id".

Fetches db only if id exists