### PR TITLE
Button layout and auth errors

### DIFF
--- a/src/components/AuthModal.vue
+++ b/src/components/AuthModal.vue
@@ -11,6 +11,9 @@
           </div>
 
           <form class='session-form'>
+            <ul>
+              <li v-for="error in errors" class="error-text">Invalid username or password</li>
+            </ul>
             <input v-model='username' placeholder='Username'>
             <br>
             <input v-model='password' placeholder='Password' type='password'>
@@ -43,6 +46,9 @@ export default {
     'authType'
   ],
   computed: {
+    errors: function () {
+      return this.$store.state.errors
+    },
     header: function () {
       if (this.authType === 'login') {
         return 'Log In'
@@ -151,6 +157,18 @@ export default {
   flex-direction: column;
   justify-content: center;
   align-items: center;
+
+  ul {
+    margin: 0;
+    padding: 0;
+  }
+
+  li {
+    list-style: none;
+    font-size: 0.6em;
+    color: $light-accent;
+    padding: 2px 0;
+  }
 
   input {
     -webkit-appearance: none;

--- a/src/components/AuthModal.vue
+++ b/src/components/AuthModal.vue
@@ -168,6 +168,7 @@ export default {
     font-size: 0.6em;
     color: $light-accent;
     padding: 2px 0;
+    justify-content: center;
   }
 
   input {

--- a/src/components/Navbar.vue
+++ b/src/components/Navbar.vue
@@ -24,16 +24,12 @@
       </button>
     </div>
     <AuthModal :authType="authType" v-if="showModal" @close="toggleModal" @toggleAuthType="toggleAuthType">
-      <!--
-        you can use custom content here to overwrite
-        default content
-      -->
     </AuthModal>
   </nav>
 </template>
 
 <script>
-import { LOGOUT, TOGGLE_NEW_DB } from '../store/mutation_types'
+import { LOGOUT, TOGGLE_NEW_DB, CLEAR_ERRORS } from '../store/mutation_types'
 import AuthModal from './AuthModal'
 export default {
   data: function () {
@@ -59,6 +55,7 @@ export default {
   },
   methods: {
     toggleAuthType: function () {
+      this.$store.commit(CLEAR_ERRORS)
       this.authType = (this.authType === 'login' ? 'signup' : 'login')
     },
     showLogIn: function () {
@@ -70,6 +67,7 @@ export default {
       this.showModal = true
     },
     toggleModal: function () {
+      this.$store.commit(CLEAR_ERRORS)
       this.showModal = !this.showModal
     },
     logout: function (e) {
@@ -118,7 +116,6 @@ export default {
       border-radius: 5px;
       padding: 0 20px;
       margin: 0 20px;
-      margin-left: 60px;
       font-family: $heading;
       font-size: 14px;
       font-weight: bold;

--- a/src/components/editor/Editor.vue
+++ b/src/components/editor/Editor.vue
@@ -232,12 +232,14 @@ export default {
     max-width: calc(100% - 300px);
     flex-direction: column;
     box-sizing: border-box;
+    position: relative;
   }
 
   .paper-menu {
-    position: fixed;
-    width: 100px;
-    bottom: 15px;
-    right: 10px;
+    position: absolute;
+    height: 120px;
+    width: 90px;
+    top: 0px;
+    left: 0px;
   }
 </style>

--- a/src/components/editor/Preview.vue
+++ b/src/components/editor/Preview.vue
@@ -1,5 +1,5 @@
 <template lang="html">
-  <section class="fixed-container">
+  <section>
     <section class="sql-preview" v-bind:class="{ pinned: pinned }">
       <header>
         <span class="heading-text">SQL Preview</span>
@@ -16,21 +16,23 @@
         </pre>
       </section>
     </section>
-    <section class="paper-menu">
-      <section class="small-menu">
-        <ul>
-          <li>
-            <span class='button small' @click='exportSQL'>
-              <span class='button-tooltip'>Download SQL</span>
-              <i class="fa fa-download" aria-hidden="true"></i>
-            </span>
-          </li>
-        </ul>
+    <section class="fixed-container">
+      <section class="paper-menu">
+        <span class='button' @click='addTable'>
+          <span class='button-tooltip'>Add Table</span>
+          <i class="fa fa-plus" aria-hidden="true"></i>
+        </span>
+        <section class="small-menu">
+          <ul>
+            <li>
+              <span class='button small' @click='exportSQL'>
+                <span class='button-tooltip'>Download SQL</span>
+                <i class="fa fa-download" aria-hidden="true"></i>
+              </span>
+            </li>
+          </ul>
+        </section>
       </section>
-      <span class='button' @click='addTable'>
-        <span class='button-tooltip'>Add Table</span>
-        <i class="fa fa-plus" aria-hidden="true"></i>
-      </span>
     </section>
   </section>
 </template>
@@ -43,7 +45,7 @@ export default {
   props: ['sql', 'graph'],
   data: () => ({
     languages: ['postgreSQL', 'access', 'mySQL', 'SQL Server', 'oracle'],
-    pinned: false
+    pinned: true
   }),
   computed: {
     sqlLang: {
@@ -208,14 +210,13 @@ export default {
   }
 
   .fixed-container {
-    position: fixed;
-    bottom: 15px;
-    right: 0;
-    width: 200px;
-    height: 20vh;
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100px;
+    height: 120px;
 
     .small-menu {
-      width: 100%;
       display: flex;
       align-items: flex-end;
       flex-direction: column;
@@ -262,7 +263,7 @@ export default {
     font-family: $heading;
     font-size: 14px;
     padding: 5px 10px;
-    right: 80px;
+    left: 80px;
     width: 100px;
     z-index: 12;
     font-weight: bold;
@@ -271,7 +272,7 @@ export default {
   .paper-menu {
     display: flex;
     flex-direction: column;
-    align-items: flex-end;
+    align-items: flex-start;
     padding: 10px;
 
     .button {

--- a/src/components/home/Home.vue
+++ b/src/components/home/Home.vue
@@ -6,6 +6,7 @@
         <li @click="$router.push('/home/features')"> Features </li>
         <li @click="$router.push('/home/about')"> About Us </li>
       </ul>
+      <a href="https://github.com/ccankov/schemer" target="_blank"><i class="fa fa-github" aria-hidden="true"></i></a>
     </aside>
     <router-view></router-view>
   </div>
@@ -35,6 +36,19 @@ export default {
     width: 20vw;
     min-width: 300px;
     display: flex;
+    flex-direction: column;
+    justify-content: space-between;
+    align-items: center;
+
+    a {
+      padding: 20px;
+      font-size: 2.5em;
+      color: $gray;
+    }
+
+    a:hover {
+      color: $light-accent;
+    }
   }
 
   .body {

--- a/src/components/home/Home.vue
+++ b/src/components/home/Home.vue
@@ -23,6 +23,7 @@ export default {
   .home {
     padding-top: 60px;
     height: 100%;
+    min-width: 900px;
     display: flex;
     box-sizing: border-box;
   }

--- a/src/components/home/Splash.vue
+++ b/src/components/home/Splash.vue
@@ -4,6 +4,7 @@
       <div class="column">
         <h1>Design Your Database Online</h1>
         <p>Rapid prototyping of SQL database models using a visual model designer</p>
+        <button @click="$router.push('/editor')" class="button">Start</button>
       </div>
       <figure @click="$router.push('/editor')"></figure>
     </article>
@@ -36,13 +37,33 @@ export default {
     .column {
       display: flex;
       flex-direction: column;
+      justify-content: space-between;
       width: 18vw;
 
       p {
-        margin-top: 15vh;
         color: $white;
         font-family: $paragraph;
         font-size: 3vh;
+      }
+
+      button {
+        display: block;
+        border-radius: 5px;
+        padding: 5px 20px;
+        margin: 0 20px;
+        margin-left: 60px;
+        font-family: $heading;
+        font-size: 1.8em;
+        font-weight: bold;
+        background-color: $light-accent;
+        color: $white;
+        border: 0;
+      }
+
+      button:hover {
+        cursor: pointer;
+        color: $white;
+        background-color: $accent;
       }
     }
 
@@ -62,6 +83,8 @@ export default {
       background-size: cover;
       box-shadow: 0 0 4px rgba(0,0,0,.28), 0 6px 12px rgba(0,0,0,.56);
       transition: 0.3s;
+      margin: 0;
+      margin-left: 40px;
     }
 
     figure:hover {


### PR DESCRIPTION
Added a start button to the splash page along with some minor visual changes. Could use a test run on a monitor with a different resolution. The auth modals now correctly show auth errors.

Home page now has a Github link in the sidebar.

On the editor screen, the add table button has been moved to the top left. Also, the SQL Preview defaults to being pinned. 