### PR TITLE
Save whole db when done editing name

### DIFF
--- a/src/components/editor/Editor.vue
+++ b/src/components/editor/Editor.vue
@@ -110,13 +110,11 @@ export default {
       this.editName = true
     },
     disableEdit: function () {
-      if (this.editName) {
-        this.$store.commit(RECEIVE_DBNAME, { dbName: this.dbName })
-        if (this.$store.state.currentUser) {
-          updateGraph(JSON.stringify(this.$store.state.graphJSON))
-        }
-      }
       this.editName = false
+      if (!this.editName) {
+        this.$store.commit(RECEIVE_DBNAME, { dbName: this.dbName })
+        this.saveDb()
+      }
     },
     saveDb: function () {
       if (this.$store.state.currentUser) {


### PR DESCRIPTION
Before: @keyup.enter in dbName input field, save whole db to database
Now: @keyup.enter in dbName input field, save whole db to database + fetch user graphs, so that the load dropdown also updates